### PR TITLE
Haskell seed

### DIFF
--- a/Haskell/.gitignore
+++ b/Haskell/.gitignore
@@ -1,0 +1,2 @@
+dist-newstyle
+cabal.project.local

--- a/Haskell/CHANGELOG.md
+++ b/Haskell/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for Haskell Katapult
+
+## 0.1.0.0 -- 2023-02-07
+
+* Hmmm… Cabal !

--- a/Haskell/Haskell.cabal
+++ b/Haskell/Haskell.cabal
@@ -1,0 +1,26 @@
+cabal-version:      2.4
+name:               Katapult
+version:            0.1.0.0
+
+author:             Laurent Bossavit
+maintainer:         laurent.git@bossavit.com
+
+extra-source-files: CHANGELOG.md
+
+executable Haskell
+    main-is:          Main.hs
+
+    -- Modules included in this executable, other than Main.
+    -- other-modules:
+
+    -- LANGUAGE extensions used by modules in this package.
+    -- other-extensions:
+    build-depends:    base ^>=4.17.0.0
+    hs-source-dirs:   app
+    default-language: Haskell2010
+
+Test-Suite katapult-tests
+    Type:                 exitcode-stdio-1.0
+    Main-Is:              Tests.hs
+    Build-depends:        Cabal, base, QuickCheck, hspec 
+    hs-source-dirs:       app, test

--- a/Haskell/app/App.hs
+++ b/Haskell/app/App.hs
@@ -1,0 +1,7 @@
+module App where
+
+alter :: String -> String
+alter = const "foo"
+
+greet :: String
+greet = error "Implement me!"

--- a/Haskell/app/Main.hs
+++ b/Haskell/app/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import App
+
+main :: IO ()
+main = do
+    putStrLn greet
+    putStrLn $ alter greet

--- a/Haskell/test/Tests.hs
+++ b/Haskell/test/Tests.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import Test.Hspec
+import Test.QuickCheck
+
+import App
+
+main = hspec $ do
+    describe "Greeting the world" $ do
+       it "Says hello" $
+            greet `shouldBe` "Hello, world !"
+    describe "Altering the greeting (to show off property-based testing)" $ do
+        it "Preserves the length of a greeting" $
+            property (\greeting -> length greeting == length (alter greeting))


### PR DESCRIPTION
Le cadre de base pour un Kata en Haskell, utilisant Cabal.

Pour lancer les tests: `cabal test`
